### PR TITLE
Fixed FTP download resume Bug(it doesn't resume the download correctl…

### DIFF
--- a/LxFTPRequest/LxFTPRequest.m
+++ b/LxFTPRequest/LxFTPRequest.m
@@ -439,7 +439,7 @@ void resourceListReadStreamClientCallBack(CFReadStreamRef stream, CFStreamEventT
     CFReadStreamSetProperty(self.readStream, kCFStreamPropertyFTPPassword, (__bridge CFTypeRef)self.password);
     CFReadStreamSetProperty(self.readStream, kCFStreamPropertyFTPFetchResourceInfo, kCFBooleanTrue);
     CFReadStreamSetProperty(self.readStream, kCFStreamPropertyFTPAttemptPersistentConnection, kCFBooleanFalse);
-    CFReadStreamSetProperty(self.readStream, kCFStreamPropertyFileCurrentOffset, (__bridge CFTypeRef) @(self.finishedSize));
+    CFReadStreamSetProperty(self.readStream, kCFStreamPropertyFTPFileTransferOffset, (__bridge CFTypeRef) @(self.finishedSize));
 
     Boolean supportsAsynchronousNotification = CFReadStreamSetClient(self.readStream,
                                                                      kCFStreamEventNone |


### PR DESCRIPTION
Fixed FTP download resume Bug(it doesn't resume the download correctly). Should use kCFStreamPropertyFTPFileTransferOffset.